### PR TITLE
fix broken examples link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ go run .
 ```
 
 ## Examples
-See the [examples folder](/tree/main/examples) for more details and usage examples.
+See the [examples folder](tree/main/examples) for more details and usage examples.
 
 #### Python
 ```python

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ go run .
 ```
 
 ## Examples
-See the [examples folder](tree/main/examples) for more details and usage examples.
+See the [examples folder](examples) for more details and usage examples.
 
 #### Python
 ```python


### PR DESCRIPTION
This PR is to fix examples link in the readme

**Before:** Clicking examples link on Github results in 404
**After:** Clicking examples link on Github shows examples folder
<img width="742" alt="Screenshot 2024-12-27 at 18 22 39" src="https://github.com/user-attachments/assets/20635281-91d1-4578-af62-281ef08cc1f0" />




